### PR TITLE
Add README note about TEXTURE_MIN_FILTER NEAREST on the Lookup table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ uniform sampler2D uLookup;
 	gl_FragColor = transform(original, uLookup);
 ```
 
+> ❗**Important**: Make sure to set `TEXTURE_MIN_FILTER` and `TEXTURE_MAG_FILTER` to `NEAREST` on the lookup table texture.
+
 ## Flipped Y Lookup
 
 Depending on your environment, the Y texture coordinate may need to be inverted during the lookup to get the correct color output. If your colours look messed up, this is most likely the case. Require the inverted function like so:


### PR DESCRIPTION
Thank you for this shader.

When I first tried using it with three.js however, the output looked like this:

![screen shot 2016-12-06 at 11 40 12 pm](https://cloud.githubusercontent.com/assets/212305/20959129/23b3752e-bc0e-11e6-98ff-4c3975ecfb5c.png)

The fix was to set both `TEXTURE_MIN_FILTER` and `TEXTURE_MAG_FILTER` to `NEAREST` on the lookup table texture:

![screen shot 2016-12-06 at 11 39 54 pm](https://cloud.githubusercontent.com/assets/212305/20959141/37eb4c92-bc0e-11e6-94d6-af1747678dcf.png)


This PR adds a note about that requirement in case anyone else runs into this problem
